### PR TITLE
added support for solaris 10 in fetch.pp

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -116,7 +116,7 @@ define wget::fetch (
     unless      => $unless_test,
     environment => $environment,
     user        => $exec_user,
-    path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin',
+    path        => '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin:/usr/sfw/bin',
     require     => Class['wget'],
   }
 


### PR DESCRIPTION
wget is in /usr/sfw/bin under solaris 10, so add it to the exec path