### PR TITLE
Add parameter to set file mode on destination

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -27,6 +27,7 @@ define wget::fetch (
   $cache_file         = undef,
   $flags              = undef,
   $backup             = true,
+  $mode               = undef,
 ) {
 
   include wget
@@ -145,6 +146,7 @@ define wget::fetch (
       ensure  => file,
       source  => "${cache_dir}/${cache}",
       owner   => $execuser,
+      mode    => $mode,
       require => Exec["wget-${name}"],
       backup  => $backup,
     }


### PR DESCRIPTION
This change exposes a $mode parameter that can be used along with $cache_dir to specify the file mode of the destination file.

