### PR TITLE
-N flag is not neccessary due to unless_test

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -95,7 +95,7 @@ define wget::fetch (
 
   $output_option = $cache_dir ? {
     undef   => " --output-document='${destination}'",
-    default => " -N -P '${cache_dir}'",
+    default => " -P '${cache_dir}'",
   }
 
   # again, not using stdlib.concat, concatanate array of headers into a single string

--- a/spec/defines/fetch_spec.rb
+++ b/spec/defines/fetch_spec.rb
@@ -78,7 +78,7 @@ describe 'wget::fetch' do
     })}
 
     it { should contain_exec('wget-test').with({
-      'command' => "wget --no-verbose -N -P '/tmp/cache' 'http://localhost/source'",
+      'command' => "wget --no-verbose -P '/tmp/cache' 'http://localhost/source'",
       'environment' => []
     }) }
 
@@ -97,7 +97,7 @@ describe 'wget::fetch' do
     })}
 
     it { should contain_exec('wget-test').with({
-      'command' => "wget --no-verbose -N -P '/tmp/cache' 'http://localhost/source'",
+      'command' => "wget --no-verbose -P '/tmp/cache' 'http://localhost/source'",
       'environment' => []
     }) }
 


### PR DESCRIPTION
The -N flag does nothing for us since the unless_test is checking whether the file is there. If the timestamp has updated on the server, this command never runs anyway. -N can cause some issues in certain circumstances.