### PR TITLE
Improvement to $destination param (issue #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ install wget:
 ```puppet
     wget::fetch { "download Google's index":
       source      => 'http://www.google.com/index.html',
-      destination => '/tmp/index.html',
+      destination => '/tmp/',
       timeout     => 0,
       verbose     => false,
     }
@@ -27,17 +27,38 @@ or alternatively:
 
 ```puppet
     wget::fetch { 'http://www.google.com/index.html':
-      destination => '/tmp/index.html',
+      destination => '/tmp/',
       timeout     => 0,
       verbose     => false,
     }
 ```
+
+If `$destination` ends in either a forward or backward slash, it will treat the destination as a directory and name the file with the basename of the `$source`.
+```puppet
+  wget::fetch { 'http://mywebsite.com/apples':
+    destination => '/downloads/',
+  }
+```
+
+Download from an array of URLs into one directory
+```puppet
+  $manyfiles = [
+    'http://mywebsite.com/apples',
+    'http://mywebsite.com/oranges',
+    'http://mywebsite.com/bananas',
+  ]
+
+  wget::fetch { $manyfiles:
+    destination => '/downloads/',
+  }
+```
+
 This fetches a document which requires authentication:
 
 ```puppet
     wget::fetch { 'Fetch secret PDF':
       source      => 'https://confidential.example.com/secret.pdf',
-      destination => '/tmp/secret.pdf',
+      destination => '/tmp/',
       user        => 'user',
       password    => 'p$ssw0rd',
       timeout     => 0,
@@ -51,7 +72,7 @@ wget options to only re-download if the source file has been updated.
 
 ```puppet
     wget::fetch { 'https://tool.com/downloads/tool-1.0.tgz':
-      destination => '/tmp/tool-1.0.tgz',
+      destination => '/tmp/',
       cache_dir   => '/var/cache/wget',
     }
 ```

--- a/spec/defines/fetch_spec.rb
+++ b/spec/defines/fetch_spec.rb
@@ -156,4 +156,15 @@ describe 'wget::fetch' do
       'unless'  => "echo 'd41d8cd98f00b204e9800998ecf8427e  #{destination}' | md5sum -c --quiet",
     })}
   end
+
+  context "download to dir", :compile do
+    let(:params) { super().merge({
+      :destination => '/tmp/dest/',
+    })}
+  
+    it { should contain_exec('wget-test').with({
+      'command' => "wget --no-verbose --output-document=\"#{destination}//source\" \"http://localhost/source\"",
+      'environment' => []
+    }) }
+  end
 end


### PR DESCRIPTION
This is for Issue #51. First attempt was PR https://github.com/maestrodev/puppet-wget/pull/56, which was closed because owner of repo wanted it improved further. I'll quote the original PR below.

> This modification allows you to iterate over an array of URLs and wget them all to one directory. This currently has to be done with 4 separate declarations of
```wget::fetch { 'http://url': destination => '/path' }```
```
  $manyfiles = [
    'https://www.kernel.org/pub/linux/kernel/v1.0/linux-1.0.tar.gz',
    'https://www.kernel.org/pub/linux/kernel/v1.0/linux-1.0.tar.sign',
    'https://www.kernel.org/pub/linux/kernel/v1.0/linux-1.0.tar.xz',
  ]
  wget::fetch { $manyfiles:
    destination => '/tmp/',
  }
```

> And another way it has improved: Given the most simple of example of using your module, just downloading a single file, you no longer have to specify the filename. It just takes the file's name of the URL. Looks a lot cleaner imho.
```
wget::fetch { 'https://www.kernel.org/pub/linux/kernel/v1.0/linux-1.0.tar.bz2':
    destination_dir => '/tmp/',
  }
```
Read PR https://github.com/maestrodev/puppet-wget/pull/56 for more detail on why the original implementation did not work.

To make it work, owner originally requested the improvement be: No new params for this feature, so make it if `$destination` already exists as a directory, then treat it as a directory. But checking to see if a directory exists is difficult to do with Puppet (and impossible to do cleanly).

So I settled on the following design which looks and works great. Better than the original PR too imho: If `$destination` ends in a forward or backward slash, then treat as a directory. With this, we were able to achieve:
  1. Backwards compatibility with older versions
  1. No new parameters have been added

Old style still works too:
```
  wget::fetch { 'https://www.kernel.org/pub/linux/kernel/v1.0/linux-1.0.tar.bz2':
    destination => '/tmp/something.bz2',
  }
```