### PR TITLE
Adding the possibility to specify the unless condition manually

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -28,6 +28,7 @@ define wget::fetch (
   $flags              = undef,
   $backup             = true,
   $mode               = undef,
+  $unless             = undef,
 ) {
 
   include wget
@@ -59,7 +60,10 @@ define wget::fetch (
     $unless_test = "cmd.exe /c \"dir ${destination}\""
   } else {
     $exec_path = '/usr/bin:/usr/sbin:/bin:/usr/local/bin:/opt/local/bin:/usr/sfw/bin'
-    if $redownload == true or $cache_dir != undef  {
+    if $unless != undef {
+      $unless_test = $unless
+    }
+    elsif $redownload == true or $cache_dir != undef  {
       $unless_test = 'test'
     } else {
       $unless_test = "test -s '${destination}'"


### PR DESCRIPTION
This way users can add their specific condition (not just if the file exist or need to be replaced)

E.g. thinking about the possibility, to automatically download the latest version of Wordpress in the VirtualHost directory just if the directory if empty (and, e.g., if it already have been deployed/uncompressed, I don't want wget to download it anymore).

```ruby
wget::fetch { 'wget_wordpress':
    source      => 'https://wordpress.org/latest.tar.gz',
    destination => "$webserver_wwwroot/latest_wordpress.tar.gz",
    timeout     => 0,
    unless      => 'test "$(ls -A . 2>/dev/null)"',
  }
```