### PR TITLE
Use $facts hash; set $schedule parameter.

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -28,6 +28,7 @@ define wget::fetch (
   $flags              = undef,
   $backup             = true,
   $mode               = undef,
+  $schedule           = undef,
 ) {
 
   include wget
@@ -46,11 +47,11 @@ define wget::fetch (
     }
   }
 
-  $http_proxy_env = $::http_proxy ? {
+  $http_proxy_env = $::facts['http_proxy'] ? {
     undef   => [],
     default => [ "HTTP_PROXY=${::http_proxy}", "http_proxy=${::http_proxy}" ],
   }
-  $https_proxy_env = $::https_proxy ? {
+  $https_proxy_env = $::facts['https_proxy'] ? {
     undef   => [],
     default => [ "HTTPS_PROXY=${::https_proxy}", "https_proxy=${::https_proxy}" ],
   }


### PR DESCRIPTION
I needed these changes in order to make your module compatible with strict_variables mode, which will become the default in Puppet 5.