### PR TITLE
Changed fetch exec require from Class to Package

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -158,7 +158,7 @@ define wget::fetch (
     environment => $environment,
     user        => $exec_user,
     path        => $exec_path,
-    require     => Class['wget'],
+    require     => Package['wget'],
     schedule    => $schedule,
   }
 


### PR DESCRIPTION
This fixes a bug where another module installs the wget package and this
module tries to run the command before it is actually installed