### PR TITLE
Add 'group' option and document 'execuser'

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ this case you must inform the correct filename in the cache like this:
       cache_dir   => '/var/cache/wget',
       cache_file  => 'tool-1.1.tgz',
       execuser    => 'fileowner',
+      group       => 'filegroup',
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ this case you must inform the correct filename in the cache like this:
       destination => '/tmp/tool-1.0.tgz',
       cache_dir   => '/var/cache/wget',
       cache_file  => 'tool-1.1.tgz',
+      execuser    => 'fileowner',
     }
 ```
 

--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -27,6 +27,7 @@ define wget::fetch (
   $cache_file         = undef,
   $flags              = undef,
   $backup             = true,
+  $group              = undef,
   $mode               = undef,
   $unless             = undef,
 ) {
@@ -193,6 +194,7 @@ define wget::fetch (
       ensure   => file,
       source   => "${cache_dir}/${cache}",
       owner    => $execuser,
+      group    => $group,
       mode     => $mode,
       require  => Exec["wget-${name}"],
       backup   => $backup,


### PR DESCRIPTION
Like `mode`, `group` is handy to have set. Also, it is nice to have `execuser` documented.