### PR TITLE
Fixing package source not found on FreeBSD.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,15 +10,21 @@ class wget (
 ) {
 
   if $manage_package {
-    if $::kernel == 'Linux' {
-      if ! defined(Package['wget']) {
+    if !defined(Package['wget']) {
+      if $::kernel == 'Linux' {
         package { 'wget': ensure => $version }
       }
-    }
-  
-    if $::kernel == 'FreeBSD' {
-      if ! defined(Package['ftp/wget']) {
-        package { 'ftp/wget': ensure => $version }
+      elsif $::kernel == 'FreeBSD' {
+        if versioncmp($::operatingsystemmajrelease, '10') >= 0 {
+          package { 'wget': ensure => $version }
+        }
+        else {
+          package { 'wget':
+            name   => 'ftp/wget',
+            ensure => $version,
+            alias  => 'wget';
+          }
+        }
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -113,6 +113,13 @@
         "12",
         "13"
       ]
+    },
+    {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "9",
+        "10"
+      ]
     }
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -34,9 +34,10 @@ describe 'wget' do
   context 'running on FreeBSD', :compile do
     let(:facts) { {
       :operatingsystem => 'FreeBSD',
-      :kernel => 'FreeBSD'
+      :kernel => 'FreeBSD',
+      :operatingsystemmajrelease => '10'
     } }
 
-    it { should contain_package('ftp/wget') }
+    it { should contain_package('wget') }
   end
 end


### PR DESCRIPTION
This fixes the issue where `wget::fetch` couldn't find the required resource package wget (`require     => Package['wget']`).