### PR TITLE
Fix doubled slash in destination

### DIFF
--- a/manifests/fetch.pp
+++ b/manifests/fetch.pp
@@ -48,7 +48,7 @@ define wget::fetch (
     /^.*\/$/, /^.*\$/:  {
       $source_split    = split($source, '/')  # split the URL into arrays, using "/" as a delimiter
       $source_filename = $source_split[-1]    # take the very last value in the array. this is the filename
-      $_destination    = "${destination}/${source_filename}"
+      $_destination    = "${destination}${source_filename}"
     }
     default: {
       $_destination = $destination


### PR DESCRIPTION
The case verifies that `$destination` ends in a slash, so adding another slash is redundant and creates an invalid path resulting in an error message: `No such file or directory`.